### PR TITLE
Remove capture from focus and blur events to prevent the lottie player from pausing on any blur from any element in the page

### DIFF
--- a/src/component/index.ts
+++ b/src/component/index.ts
@@ -460,8 +460,8 @@ export class DotLottiePlayer extends LitElement {
       this.container.addEventListener('mouseleave', this._mouseLeave)
     }
 
-    addEventListener('focus', this._handleWindowBlur, { passive: true, capture: true })
-    addEventListener('blur', this._handleWindowBlur, { passive: true, capture: true })
+    addEventListener('focus', this._handleWindowBlur, { passive: true, capture: false })
+    addEventListener('blur', this._handleWindowBlur, { passive: true, capture: false })
 
     if (this.animateOnScroll) {
       addEventListener('scroll', this._handleScroll, { passive: true, capture: true })


### PR DESCRIPTION
Adding an event listener with `capture: true` on the `Window` element makes every single event of that type trigger the handler.

Therefore, any `blur` on any element in a page containing one or several `dotlottie-player` or `dotlottie-player-light` will call the `_handleWindowBlur` method on every last one of them and pause them all.

You can see an example of this on your demo page. If you click a button and then click anywhere else in the page (thus triggering the `blur` event on the button), the demo player will pause.