### PR TITLE
Fix manifest precedence regression

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -252,7 +252,7 @@ export class DotLottiePlayer extends LitElement {
     // Loop
     let loop = !!this.loop
     // This results in unwanted behavior, and is disabled
-    // if (currentAnimationManifest.loop !== undefined) {
+    // if (currentAnimationManifest.loop !== undefined && !this.loop) {
     //   loop = !!currentAnimationManifest.loop
     // }
     if (currentAnimationSettings?.loop !== undefined) {
@@ -261,7 +261,7 @@ export class DotLottiePlayer extends LitElement {
 
     // Autoplay
     let autoplay = !!this.autoplay
-    if (currentAnimationManifest.autoplay !== undefined) {
+    if (currentAnimationManifest.autoplay !== undefined && !this.autoplay) {
       autoplay = !!currentAnimationManifest.autoplay
     }
     if (currentAnimationSettings?.autoplay !== undefined) {

--- a/src/component.ts
+++ b/src/component.ts
@@ -251,7 +251,7 @@ export class DotLottiePlayer extends LitElement {
 
     // Loop
     let loop = !!this.loop
-    if (currentAnimationManifest.loop !== undefined && !this.loop) {
+    if (currentAnimationManifest.loop !== undefined && this.loop === undefined) {
       loop = !!currentAnimationManifest.loop
     }
     if (currentAnimationSettings?.loop !== undefined) {
@@ -260,7 +260,7 @@ export class DotLottiePlayer extends LitElement {
 
     // Autoplay
     let autoplay = !!this.autoplay
-    if (currentAnimationManifest.autoplay !== undefined && !this.autoplay) {
+    if (currentAnimationManifest.autoplay !== undefined && this.autoplay === undefined) {
       autoplay = !!currentAnimationManifest.autoplay
     }
     if (currentAnimationSettings?.autoplay !== undefined) {

--- a/src/component.ts
+++ b/src/component.ts
@@ -251,10 +251,9 @@ export class DotLottiePlayer extends LitElement {
 
     // Loop
     let loop = !!this.loop
-    // This results in unwanted behavior, and is disabled
-    // if (currentAnimationManifest.loop !== undefined && !this.loop) {
-    //   loop = !!currentAnimationManifest.loop
-    // }
+    if (currentAnimationManifest.loop !== undefined && !this.loop) {
+      loop = !!currentAnimationManifest.loop
+    }
     if (currentAnimationSettings?.loop !== undefined) {
       loop = !!currentAnimationSettings.loop
     }


### PR DESCRIPTION
The 2.4.11 refactor introduced a regression in which the `manifest` takes precedence over user entered parameters for `loop` and `autoplay`, making it impossible to loop or autoplay a lottie file if these are set to `false` in their manifest.

This PR fixes this regression.

PS: I uncommented the loop logic being disabled since I presumed it was commented because of the aforementionned regression.